### PR TITLE
Doc: fix node "require" statement in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ npm install snappy
 ### Input
 
 ```javascript
-var snappy = require('./snappy')
+var snappy = require('snappy')
 
 snappy.compress('beep boop', function (err, compressed) {
   console.log('compressed is a Buffer', compressed)


### PR DESCRIPTION
use dot only in `require('path')` only
if you save module after `npm install` is unnecessary