### PR TITLE
fix url in readme to snappy repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # snappy [![Linux Status](https://img.shields.io/travis/kesla/node-snappy.svg?label=linux)](https://travis-ci.org/kesla/node-snappy) [![Windows Status](https://img.shields.io/appveyor/ci/kesla/node-snappy.svg?label=windows)](https://ci.appveyor.com/project/kesla/node-snappy)
 
-Nodejs bindings to the [snappy](github.com/google/snappy) compression library
+Nodejs bindings to the [snappy](https://github.com/google/snappy) compression library
 
 [![NPM](https://nodei.co/npm/snappy.png?downloads&stars)](https://nodei.co/npm/snappy/)
 


### PR DESCRIPTION
The URL in the readme to the snappy repo is missing the protocol...