### PR TITLE
Updated tap to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node-gyp": "3.0.3"
   },
   "devDependencies": {
-    "tap": "0.4.13"
+    "tap": "2.0.0"
   },
   "gypfile": true,
   "bugs": {


### PR DESCRIPTION
:rocket:

tap just published version 2.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 271 commits (ahead by 271, behind by 0).

- [e734348](https://github.com/isaacs/node-tap/commit/e734348831f0201f8b9c96c9a9746cf75e48bc06): v2.0.0
- [ba8b7ed](https://github.com/isaacs/node-tap/commit/ba8b7ed296bfceefe5413438977845e33552a3eb): Merge branch 'pending-handles'
- [b833bd9](https://github.com/isaacs/node-tap/commit/b833bd986ecbc5b5bbecb70d4a76f748f8e6e6c7): doc: improve assert documentation, move advanced to bottom
- [4a3975c](https://github.com/isaacs/node-tap/commit/4a3975c7f5cfca6b407c7eb20d9daa1611bbfdf8): use latest glob
- [1999f77](https://github.com/isaacs/node-tap/commit/1999f774ce5c6110792f424637e088c12d1e5169): pending handles test: remove server/fs, too inconsistent on Travis
- [a121ca4](https://github.com/isaacs/node-tap/commit/a121ca4af8529c31c9c63afee462cb928ed1747b): Use consistent assert version in mochalike test
- [ee52ee4](https://github.com/isaacs/node-tap/commit/ee52ee4fc0cd000f3a772bdb4b7571a5efb2df52): remove unused fixture
- [027f10e](https://github.com/isaacs/node-tap/commit/027f10e9d1ec4ec42461bb3cade6fd4b91c26c62): travis: use new infrastructure
- [f8da831](https://github.com/isaacs/node-tap/commit/f8da831750b5010e67d3b627e3d02aec247b3fc3): Use tmatch, and actually test yaml output in test tests
- [51d51d5](https://github.com/isaacs/node-tap/commit/51d51d5f9b0d3eec30d3e786d8302ed0774ec168): Use signal-exit to only respond to fatal SIGTERMs
- [365db0e](https://github.com/isaacs/node-tap/commit/365db0eaa34a2306468d319c0c91d4662f9cdfe6): runner test: use slower timeout when coverage enabled
- [1b64687](https://github.com/isaacs/node-tap/commit/1b64687c8c1e5286fce8f20754f5b4444c27a00a): Generate test tests JSON such that arrays are preserved
- [77f9c11](https://github.com/isaacs/node-tap/commit/77f9c11cea9397dbd403f232e80966a3d50cd7df): update travis.yml to drop 0.8 and add node 4
- [774037b](https://github.com/isaacs/node-tap/commit/774037bc0bd9d48f9c809bf336634b3a5442d1f8): Emit a more useful failure on child proc timeout
- [93ee76e](https://github.com/isaacs/node-tap/commit/93ee76e21211188c6d5606624c560bdaf2231d99): v1.4.1


There are 250 commits in total. See the [full diff](https://github.com/isaacs/node-tap/compare/6ae608ce80da71e96fe58fb56fd693854343e513...e734348831f0201f8b9c96c9a9746cf75e48bc06).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>