### PR TITLE
Updated tap to version 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node-gyp": "3.0.3"
   },
   "devDependencies": {
-    "tap": "0.4.13"
+    "tap": "2.0.1"
   },
   "gypfile": true,
   "bugs": {


### PR DESCRIPTION
:rocket:

tap just published version 2.0.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 275 commits (ahead by 275, behind by 0).

- [77f6dd6](https://github.com/isaacs/node-tap/commit/77f6dd60f2df1cf7db7a5e0f979587f71c968bad): v2.0.1
- [66350ee](https://github.com/isaacs/node-tap/commit/66350eee83cf52d2d5c3a62add5977b47b57ab2a): Skip pending-handles test on Travis.  Too timing dependent.
- [7bbcacb](https://github.com/isaacs/node-tap/commit/7bbcacbdc4cc7133fd22054cc5f3e2c7dea4bed8): root-teardown test: allow more time, 10ms isn't enough
- [c781bd9](https://github.com/isaacs/node-tap/commit/c781bd91dc8d1b19d4d48dd4b7cbd7a433151c35): Remove domains
- [e734348](https://github.com/isaacs/node-tap/commit/e734348831f0201f8b9c96c9a9746cf75e48bc06): v2.0.0
- [ba8b7ed](https://github.com/isaacs/node-tap/commit/ba8b7ed296bfceefe5413438977845e33552a3eb): Merge branch 'pending-handles'
- [b833bd9](https://github.com/isaacs/node-tap/commit/b833bd986ecbc5b5bbecb70d4a76f748f8e6e6c7): doc: improve assert documentation, move advanced to bottom
- [4a3975c](https://github.com/isaacs/node-tap/commit/4a3975c7f5cfca6b407c7eb20d9daa1611bbfdf8): use latest glob
- [1999f77](https://github.com/isaacs/node-tap/commit/1999f774ce5c6110792f424637e088c12d1e5169): pending handles test: remove server/fs, too inconsistent on Travis
- [a121ca4](https://github.com/isaacs/node-tap/commit/a121ca4af8529c31c9c63afee462cb928ed1747b): Use consistent assert version in mochalike test
- [ee52ee4](https://github.com/isaacs/node-tap/commit/ee52ee4fc0cd000f3a772bdb4b7571a5efb2df52): remove unused fixture
- [027f10e](https://github.com/isaacs/node-tap/commit/027f10e9d1ec4ec42461bb3cade6fd4b91c26c62): travis: use new infrastructure
- [f8da831](https://github.com/isaacs/node-tap/commit/f8da831750b5010e67d3b627e3d02aec247b3fc3): Use tmatch, and actually test yaml output in test tests
- [51d51d5](https://github.com/isaacs/node-tap/commit/51d51d5f9b0d3eec30d3e786d8302ed0774ec168): Use signal-exit to only respond to fatal SIGTERMs
- [365db0e](https://github.com/isaacs/node-tap/commit/365db0eaa34a2306468d319c0c91d4662f9cdfe6): runner test: use slower timeout when coverage enabled


There are 250 commits in total. See the [full diff](https://github.com/isaacs/node-tap/compare/6ae608ce80da71e96fe58fb56fd693854343e513...77f6dd60f2df1cf7db7a5e0f979587f71c968bad).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>