### PR TITLE
AppVeyor support for node 12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ platform:
   - x64
 
 install:
-  - ps: Install-Product node $env:nodejs_version $env:platform
-  - set PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
+  # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - npm ci || npm i
 
 test_script:


### PR DESCRIPTION
AppVeyor doesn't support node 12 yet, so let's try workaround in https://github.com/appveyor/ci/issues/2921.

Fixes #172