### PR TITLE
Fix broken 'npm install' in node v4 on OS X 10.15.4

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,11 @@
       'includes': [ 'deps/snappy/common.gypi' ],
       'include_dirs': [ '<!(node -e "require(\'nan\')")', 'deps/snappy/<(os_include)' ],
       'dependencies': [ 'deps/snappy/snappy.gyp:snappy' ],
-      'sources': [ 'src/binding.cc' ]
+      'sources': [ 'src/binding.cc' ],
+      'xcode_settings': {
+        'WARNING_CFLAGS': [ '-Wno-sign-compare', '-Wno-unused-function' ],
+        'MACOSX_DEPLOYMENT_TARGET': '10.9'
+      }
     }
   ]
 }

--- a/deps/snappy/snappy.gyp
+++ b/deps/snappy/snappy.gyp
@@ -35,7 +35,8 @@
       }],
       ['OS == "mac"', {
         'xcode_settings': {
-          'WARNING_CFLAGS': [ '-Wno-sign-compare', '-Wno-unused-function' ]
+          'WARNING_CFLAGS': [ '-Wno-sign-compare', '-Wno-unused-function' ],
+          'MACOSX_DEPLOYMENT_TARGET': '10.9'
         }
       }]
     ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "bindings": "^1.3.1",
     "nan": "^2.14.0",
-    "prebuild-install": "^5.2.2"
+    "prebuild-install": "5.2.x"
   },
   "devDependencies": {
     "ava": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "bindings": "^1.3.1",
     "nan": "^2.14.0",
-    "prebuild-install": "5.2.x"
+    "prebuild-install": "5.3.0"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
Problem description:
 - prebuild_install >5.3.0 breaks on Node v4:

```
/private/node_modules/snappy/node_modules/prebuild-install/node_modules/simple-get/index.js:18
    const { hostname, port, protocol, auth, path } = url.parse(opts.url) // eslint-disable-line node/no-deprecated-api
          ^

SyntaxError: Unexpected token {
```

 - on OSX 10.15.4, node-gyp fails:

```
clang: warning: include path for libstdc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead [-Wstdlibcxx-not-found]
../deps/snappy/snappy-1.1.7/snappy-stubs-internal.cc:29:10: fatal error: 'algorithm' file not found
#include <algorithm>
         ^~~~~~~~~~~
1 error generated.
make: *** [Release/obj.target/snappy/deps/snappy/snappy-1.1.7/snappy-stubs-internal.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
```

Related issue: #183

Fix summary:
  - pin prebuild_install to 5.3.0
  - set MACOSX_DEPLOYMENT_TARGET=10.9 in .gyp files