### PR TITLE
fix: add uncompress overload without options

### DIFF
--- a/snappy.d.ts
+++ b/snappy.d.ts
@@ -2,5 +2,6 @@ export function compress(input: string | Buffer, callback: (err: Error, buffer?:
 export function compressSync(input: string | Buffer): Buffer;
 export var isValidCompressed: (buffer: Buffer, callback: (err: Error | null, isValid?: boolean) => void) => void;
 export var isValidCompressedSync: (buffer: Buffer) => boolean;
+export function uncompress(buffer: Buffer, callback: (err: Error, uncompressed?: string | Buffer) => void): void;
 export function uncompress(compressed: Buffer, opts: any, callback: (err: Error, uncompressed?: string | Buffer) => void): void;
 export function uncompressSync(compressed: Buffer, opts: any): string | Buffer;


### PR DESCRIPTION
This adds in an overload for `uncompress` to omit the option and go use the callback as the second argument.